### PR TITLE
ci: Monitorar vagas com 90 dias de inatividade

### DIFF
--- a/.github/workflows/encerrar-vagas.yml
+++ b/.github/workflows/encerrar-vagas.yml
@@ -1,0 +1,15 @@
+name: "Encerrar vagas inativas por 90 dias"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'Inativa por 90 dias'
+        days-before-stale: 90
+        days-before-close: 0


### PR DESCRIPTION
Build diário de monitoramento de atividade das issues.

Caso uma vaga possua 90 dias sem comentário ou alteração de label, será marcada com a label `Inativa por 90 dias` e automaticamente encerrada.

Esse ajuste irá nos isentar da atividade de encerrar a vaga quando chegar nos 90 dias e garantir que a regra de 90 dias esteja sendo seguida.

Action utilizada: <https://github.com/actions/stale>

### Atenção:
Antes de você aceitar o PR, vá no `secrets` do projeto e adicione o `GITHUB_TOKEN` passando o seu token. Se aceitar o PR antes o primeiro build irá ser quebrado.