### PR TITLE
Atualiza a versão do aciton/stale da v3 para v7

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v7
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60


### PR DESCRIPTION
Na versão atual (v3) não é possível fechar a issue sem comentar, por isso necessário pelo menos a versão 4 (v4) ou superior.

Parte da discussão em #1084 